### PR TITLE
Add AllWork tag to WorkTypeDef

### DIFF
--- a/1.2/Defs/WorkTypeDefs/WorkTypes_QuestionableEthics.xml
+++ b/1.2/Defs/WorkTypeDefs/WorkTypes_QuestionableEthics.xml
@@ -15,6 +15,7 @@
 		<workTags>
 			<li>Caring</li>
 			<li>Intellectual</li>
+			<li>AllWork</li>
 		</workTags>
 	</WorkTypeDef>
 </Defs>


### PR DESCRIPTION
Guests added by Royalty or mods supporting similar "lazy" functionality such as Janissaries or visitors who only come to observe and will do no work for you judge what is and is not work based on the existence of the tag "AllWork."  Although it would have been much more sensible for Tynan to have just defined the four jobs which aren't work as "NotWork", we're left with the situation that we're in.

This update will make it so that visitors from whatever mod who wind up under your control but will "refuse to do work" will not be able to Maintain Vats.